### PR TITLE
Fix repo links and build config

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -513,7 +513,7 @@ Responde con el contenido reorganizado listo para convertir en diapositivas, inc
                 </div>
               </div>
               <div>
-                <h1 className="text-3xl font-bold">PowerPoint Generator</h1>
+                <h1 className="text-3xl font-bold">SlideForge</h1>
                 <p className="text-red-100 text-sm">Generador Inteligente de Presentaciones</p>
               </div>
             </div>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SlideForge v1.2 🚀
 
-[![CI/CD Pipeline](https://github.com/RFLORESCARTES/power-point-generator/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/RFLORESCARTES/power-point-generator/actions/workflows/ci-cd.yml)
-[![Code Quality](https://github.com/RFLORESCARTES/power-point-generator/actions/workflows/code-quality.yml/badge.svg)](https://github.com/RFLORESCARTES/power-point-generator/actions/workflows/code-quality.yml)
-[![codecov](https://codecov.io/gh/RFLORESCARTES/power-point-generator/branch/main/graph/badge.svg)](https://codecov.io/gh/RFLORESCARTES/power-point-generator)
+[![CI/CD Pipeline](https://github.com/RFLORESCARTES/SlideForge-v1.2/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/RFLORESCARTES/SlideForge-v1.2/actions/workflows/ci-cd.yml)
+[![Code Quality](https://github.com/RFLORESCARTES/SlideForge-v1.2/actions/workflows/code-quality.yml/badge.svg)](https://github.com/RFLORESCARTES/SlideForge-v1.2/actions/workflows/code-quality.yml)
+[![codecov](https://codecov.io/gh/RFLORESCARTES/SlideForge-v1.2/branch/main/graph/badge.svg)](https://codecov.io/gh/RFLORESCARTES/SlideForge-v1.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Generador inteligente de presentaciones PowerPoint con IA integrada y exportación PPTX nativa**
@@ -46,15 +46,15 @@ SlideForge es una aplicación moderna de escritorio que permite crear presentaci
 ## 🚀 Instalación Rápida
 
 ### Descarga Directa (Recomendado)
-1. Descarga el archivo `.dmg` desde [Releases](https://github.com/RFLORESCARTES/power-point-generator/releases)
+1. Descarga el archivo `.dmg` desde [Releases](https://github.com/RFLORESCARTES/SlideForge-v1.2/releases)
 2. Monta el DMG y arrastra SlideForge a Aplicaciones
 3. Abre SlideForge (sin advertencias de seguridad gracias a la notarización)
 
 ### Desde Código Fuente
 ```bash
 # Clonar repositorio
-git clone https://github.com/RFLORESCARTES/power-point-generator.git
-cd power-point-generator
+git clone https://github.com/RFLORESCARTES/SlideForge-v1.2.git
+cd SlideForge-v1.2
 
 # Instalar dependencias
 npm install --legacy-peer-deps
@@ -63,6 +63,11 @@ npm install --legacy-peer-deps
 npm run dev
 
 # Construir para producción
+npm run dist:mac
+```
+Para construir sin firma de código durante el desarrollo local, ejecuta:
+```bash
+export CSC_IDENTITY_AUTO_DISCOVERY=false
 npm run dist:mac
 ```
 
@@ -288,8 +293,8 @@ git push origin v1.2.0
 - **Development Guide**: [docs/development.md](docs/development.md)
 
 ### Contacto
-- **Issues**: [GitHub Issues](https://github.com/RFLORESCARTES/power-point-generator/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/RFLORESCARTES/power-point-generator/discussions)
+- **Issues**: [GitHub Issues](https://github.com/RFLORESCARTES/SlideForge-v1.2/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/RFLORESCARTES/SlideForge-v1.2/discussions)
 
 ## 📜 Licencia
 

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PowerPoint Generator - Generador Inteligente de Presentaciones</title>
+    <title>SlideForge - Generador Inteligente de Presentaciones</title>
   </head>
   <body>
     <div id="root"></div>

--- a/main.js
+++ b/main.js
@@ -79,10 +79,10 @@ app.on('window-all-closed', () => {
 function createMenu() {
   const template = [
     {
-      label: 'PowerPoint Generator',
+      label: 'SlideForge',
       submenu: [
         {
-          label: 'Acerca de PowerPoint Generator',
+          label: 'Acerca de SlideForge',
           role: 'about'
         },
         { type: 'separator' },
@@ -93,7 +93,7 @@ function createMenu() {
         },
         { type: 'separator' },
         {
-          label: 'Ocultar PowerPoint Generator',
+          label: 'Ocultar SlideForge',
           accelerator: 'Command+H',
           role: 'hide'
         },
@@ -278,12 +278,12 @@ function createMenu() {
       label: 'Ayuda',
       submenu: [
         {
-          label: 'Acerca de PowerPoint Generator',
+          label: 'Acerca de SlideForge',
           click: () => {
             dialog.showMessageBox(mainWindow, {
               type: 'info',
-              title: 'Acerca de PowerPoint Generator',
-              message: 'PowerPoint Generator v1.0.0',
+              title: 'Acerca de SlideForge',
+              message: 'SlideForge v1.0.0',
               detail: 'Generador inteligente de presentaciones con IA\n\nDesarrollado con Electron y React\nPowered by OpenAI'
             });
           }
@@ -291,7 +291,7 @@ function createMenu() {
         {
           label: 'Documentación',
           click: () => {
-            shell.openExternal('https://github.com/tu-usuario/powerpoint-generator');
+            shell.openExternal('https://github.com/RFLORESCARTES/SlideForge-v1.2');
           }
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
-  "name": "powerpoint-generator-mac",
-  "productName": "PowerPoint Generator",
+  "name": "slideforge",
+  "productName": "SlideForge",
   "description": "Generador inteligente de presentaciones con IA",
   "version": "1.0.0",
-  "author": "PowerPoint Generator Team",
-  "homepage": "https://github.com/tu-usuario/powerpoint-generator",
-  "main": "electron/main.cjs",
+  "author": "SlideForge Team",
+  "homepage": "https://github.com/RFLORESCARTES/SlideForge-v1.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RFLORESCARTES/SlideForge-v1.2.git"
+  },
+  "main": "main.js",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -28,8 +32,13 @@
     "docs:build": "npm run docs:pdf"
   },
   "build": {
-    "appId": "com.powerpointgenerator.app",
+    "appId": "com.slideforge.app",
     "productName": "SlideForge",
+    "publish": {
+      "provider": "github",
+      "owner": "RFLORESCARTES",
+      "repo": "SlideForge-v1.2"
+    },
     "directories": {
       "output": "dist-electron"
     },
@@ -55,8 +64,8 @@
       "darkModeSupport": true,
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
-      "entitlements": "build/entitlements.plist",
-      "entitlementsInherit": "build/entitlements.plist",
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": {
         "teamId": "XXXXXXXXXX"
       },


### PR DESCRIPTION
## Summary
- update README to point at SlideForge-v1.2
- update build instructions for dev code signing
- fix repository metadata in package.json
- configure publish repo and entitlements path
- rename app references from PowerPoint Generator to SlideForge
- add macOS entitlements file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686430faeb1483298cdfb0adedecb3df